### PR TITLE
Clean up Discord integration code, and add posting of ASan logs to Discord

### DIFF
--- a/code/code/main.cc
+++ b/code/code/main.cc
@@ -10,6 +10,7 @@
 #include "enum.h"
 #include "version.h"
 #include "discord.h"
+#include <curl/curl.h>
 
 #include <stdio.h>
 
@@ -30,9 +31,9 @@ int main(int argc, char* argv[]) {
   if (!Config::doConfiguration(argc, argv))
     return 0;
 
-  if (!Discord::doConfig()) 
+  if (!Discord::doConfig())
     vlogf(LOG_MISC, "Discord configuration failed.");
-  
+
   if (Config::NoSpecials())
     vlogf(LOG_MISC, "Suppressing assignment of special routines.");
 
@@ -51,6 +52,10 @@ int main(int argc, char* argv[]) {
   }
   vlogf(LOG_MISC, format("Using %s as data directory.") % Config::DataDir());
 
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+
+  Discord::maybePostNewestCrashLog();
+
   srand(time(0));
   std::random_device rd;
   rng = std::mt19937(rd());
@@ -68,6 +73,7 @@ int main(int argc, char* argv[]) {
   int ret = run_the_game();
 
   generic_cleanup();
+  curl_global_cleanup();
 
   return ret;
 }

--- a/code/code/misc/damage.cc
+++ b/code/code/misc/damage.cc
@@ -994,8 +994,9 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
             taunt_buf = format("WOO! And %s goes down! HA!") % v->getName();
           }
           doShout(taunt_buf);
-          discord_taunt_msg = format(":skull: %s shouts, \"%s\"") % getName().cap() % taunt_buf;
-          Discord::sendMessage(Discord::CHANNEL_DEATHS, discord_taunt_msg);
+          discord_taunt_msg =
+            format(":skull: %s shouts, \"%s\"") % getName().cap() % taunt_buf;
+          Discord::sendMessageAsync(Discord::CHANNEL_DEATHS, discord_taunt_msg);
         } else {
 #if 1
           if (v == this && isPc())
@@ -1131,7 +1132,7 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
               f->follower->desc->session.groupKills++;
               f->follower->desc->career.group_kills++;
             }
-              
+
             // discord group naming
             if (f->follower->getName() != getName()) {
               if (group_members < 2) {
@@ -1149,19 +1150,29 @@ int TBeing::damageEpilog(TBeing* v, spellNumT dmg_type) {
 
     // send an achievement message to the discord webhook
     sstring achievement_msg;
-    if((isPc() || (isPet(PETTYPE_PET | PETTYPE_CHARM | PETTYPE_THRALL) && (master && master->isPc()))) && !v->isPc() && v->GetMaxLevel() >= Discord::ACHIEVEMENT_THRESHOLD) {
+    if ((isPc() || (isPet(PETTYPE_PET | PETTYPE_CHARM | PETTYPE_THRALL) &&
+                     (master && master->isPc()))) &&
+        !v->isPc() && v->GetMaxLevel() >= Discord::ACHIEVEMENT_THRESHOLD) {
       // player killed an notable mob, send message to our discord webhook
       if (group_members == 0) {
         // killer is solo
-        achievement_msg = format(":crossed_swords: **%s** has taken down **%s**!") % getName() % v->getName();
+        achievement_msg =
+          format(":crossed_swords: **%s** has taken down **%s**!") % getName() %
+          v->getName();
       } else if (group_members == 1) {
         // killer + one other group member
-        achievement_msg = format(":crossed_swords: **%s** has taken down **%s** with assistance from **%s**!") % getName() % v->getName() % lastname;
+        achievement_msg = format(
+                            ":crossed_swords: **%s** has taken down **%s** "
+                            "with assistance from **%s**!") %
+                          getName() % v->getName() % lastname;
       } else {
         // killer + a group of 2+ others
-        achievement_msg = format(":crossed_swords: **%s** has taken down **%s** with assistance from **%s** and **%s**!") % getName() % v->getName() % grouplist.str() % lastname;
+        achievement_msg = format(
+                            ":crossed_swords: **%s** has taken down **%s** "
+                            "with assistance from **%s** and **%s**!") %
+                          getName() % v->getName() % grouplist.str() % lastname;
       }
-      
+
       Discord::sendMessage(Discord::CHANNEL_ACHIEVEMENT, achievement_msg);
     }
 

--- a/code/code/misc/discord.cc
+++ b/code/code/misc/discord.cc
@@ -1,112 +1,253 @@
-#include <iostream>
-#include <fstream>
-#include <filesystem>
-#include <thread>
-
 #include "discord.h"
 
-#include "extern.h"
-#include "colorstring.h"
-#include "sstring.h"
 #include <curl/curl.h>
-#include <curl/easy.h>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iosfwd>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <thread>
 
-#include <boost/program_options.hpp>
+#include "colorstring.h"
+#include "log.h"
+#include "sstring.h"
+
 namespace po = boost::program_options;
 
 // available discord channels
 // channels are configured in lib/discord.cfg
-// new channels must be added in that file, here, in discord.h, and in po::options_descriptions below
+// new channels must be added in that file, here, in discord.h, and in
+// po::options_descriptions below
 sstring Discord::CHANNEL_DEATHS;
 sstring Discord::CHANNEL_SYS;
 sstring Discord::CHANNEL_ACHIEVEMENT;
+sstring Discord::CHANNEL_CRASH_LOGS;
 
 // threshold level for discord mob kill notifications
 int Discord::ACHIEVEMENT_THRESHOLD;
 
 // read the configuration
 bool Discord::doConfig() {
-    using std::string;
-    string configFile = "discord.cfg";
+  static constexpr std::string_view configFile = "discord.cfg";
 
-    std::string empty_string = "";
+  po::options_description config_options("Configuration File Only");
 
-    po::options_description configOnly("Configuration File Only");
-    configOnly.add_options()
-        ("deaths_webhook",po::value<string>(&CHANNEL_DEATHS)->default_value(empty_string),"see discord.h")
-        ("sys_webhook",po::value<string>(&CHANNEL_SYS)->default_value(empty_string),"see discord.h")
-        ("achieve_webhook",po::value<string>(&CHANNEL_ACHIEVEMENT)->default_value(empty_string),"see discord.h")
-        ("achieve_threshold",po::value<int>(&ACHIEVEMENT_THRESHOLD)->default_value(80),"see discord.h");
+  // clang-format off
+  config_options.add_options()
+    ("deaths_webhook", po::value<std::string>(&CHANNEL_DEATHS)->default_value(""), "see discord.h")
+    ("sys_webhook", po::value<std::string>(&CHANNEL_SYS)->default_value(""), "see discord.h")
+    ("achieve_webhook", po::value<std::string>(&CHANNEL_ACHIEVEMENT)->default_value(""), "see discord.h")
+    ("achieve_threshold", po::value<int>(&ACHIEVEMENT_THRESHOLD)->default_value(80), "see discord.h")
+    ("crash_logs_webhook", po::value<std::string>(&CHANNEL_CRASH_LOGS)->default_value(""), "see discord.h");
+  // clang-format on
 
-    po::options_description config_options;
-    config_options.add(configOnly);
+  po::variables_map vm;
+  po::notify(vm);
+  std::ifstream ifs(configFile.data());
 
-    po::variables_map vm;
-    po::notify(vm);
-    std::ifstream ifs(configFile.c_str());
+  if (!ifs.is_open()) {
+    vlogf(LOG_MISC,
+      format("Discord webhooks: Failed to open config file '%s'") % configFile);
+    vlogf(LOG_MISC,
+      format("Discord webhooks: ensure config is located in: '%s'") %
+        std::filesystem::current_path());
+    return false;
+  }
 
-    if (!ifs.is_open()) {
-        vlogf(LOG_MISC, format("Discord webhooks: Failed to open config file '%s'") % configFile);
-        vlogf(LOG_MISC, format("Discord webhooks: ensure config is located in: '%s'") % std::filesystem::current_path());
-        return false;
-    }
+  po::store(parse_config_file(ifs, config_options), vm);
+  po::notify(vm);
 
-    po::store(parse_config_file(ifs, config_options), vm);
-    po::notify(vm);
-
-    return true;
+  return true;
 }
 
-
-// send a message to a discord webhook
+// Synchronously send a message to a discord webhook
 // we use the curl library for this and keep it simple
-bool Discord::sendMessageAsync(sstring channel, sstring msg)
-{
+bool Discord::sendMessage(const sstring& channel, const sstring& msg) {
+  if (channel.empty())
+    return false;
 
-    CURL* curl = curl_easy_init();
-    if (!curl) {
-        vlogf(LOG_MISC, "Discord webhooks: curl_easy_init() failed");
-        return false;
-    }
+  CURL* curl = curl_easy_init();
+  if (!curl) {
+    vlogf(LOG_MISC, "Discord webhooks: curl_easy_init() failed");
+    return false;
+  }
 
-    // sanitize and format the message
-    msg = format("{\"content\": \"%s\"}") % stripColorCodes(msg).escapeJson();
+  const sstring formatted_msg =
+    format(R"({"content": "%s"})") % stripColorCodes(msg).escapeJson();
 
-    const char* webhookURL = channel.c_str();
-    const char* content = msg.c_str();
+  const char* webhookURL = channel.c_str();
+  const char* content = formatted_msg.c_str();
 
-    struct curl_slist* headers = NULL;
-    headers = curl_slist_append(headers, "Content-Type: application/json");
+  curl_slist* headers = nullptr;
+  headers = curl_slist_append(headers, "Content-Type: application/json");
 
-    curl_easy_setopt(curl, CURLOPT_URL, webhookURL);
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, content);
+  curl_easy_setopt(curl, CURLOPT_URL, webhookURL);
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, content);
 
-    CURLcode res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-        vlogf(LOG_MISC, format("Discord webhooks: curl_easy_perform() failed: '%s'") %  curl_easy_strerror(res));
-    }
-
+  CURLcode res = curl_easy_perform(curl);
+  if (res != CURLE_OK) {
+    vlogf(LOG_MISC,
+      format("Discord webhooks: curl_easy_perform() failed: '%s'") %
+        curl_easy_strerror(res));
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
-    return true;
+    return false;
+  }
+
+  curl_slist_free_all(headers);
+  curl_easy_cleanup(curl);
+  return true;
 }
 
-void Discord::sendMessage(sstring channel, sstring msg, bool detach) 
-{
-    if (channel == "") {
-        // no channel configuration, so bail
-        return;
+// Send Discord messages asynchronously by default so the mud doesn't hang until
+// the POST request resolves. If the caller wants to block the main thread
+// until resolution for some reason they can do so by calling sendMessage
+// directly.
+void Discord::sendMessageAsync(const sstring& channel, const sstring& msg) {
+  if (channel.empty())
+    return;
+
+  vlogf(LOG_MISC, format("Discord webhooks: '%s'") % msg);
+  std::thread(sendMessage, channel, msg).detach();
+}
+
+// Post a file to a discord channel via webhook, to allow messages longer than
+// the character limit to be posted all at once (such as crash logs)
+bool Discord::sendFile(const sstring& channel, const sstring& filePath) {
+  if (channel.empty())
+    return false;
+
+  CURL* curl = curl_easy_init();
+
+  if (!curl) {
+    vlogf(LOG_MISC, "Discord webhooks: curl_easy_init() failed");
+    return false;
+  }
+
+  const char* const webhookURL = channel.c_str();
+  curl_easy_setopt(curl, CURLOPT_URL, webhookURL);
+
+  struct curl_httppost* formpost = nullptr;
+  struct curl_httppost* lastptr = nullptr;
+  curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, "file", CURLFORM_FILE,
+    filePath.c_str(), CURLFORM_END);
+
+  curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
+
+  CURLcode res = curl_easy_perform(curl);
+
+  if (res != CURLE_OK) {
+    vlogf(LOG_MISC,
+      format("curl_easy_perform() failed: %s") % curl_easy_strerror(res));
+    curl_easy_cleanup(curl);
+    curl_formfree(formpost);
+    return false;
+  }
+
+  curl_easy_cleanup(curl);
+  curl_formfree(formpost);
+  return true;
+}
+
+void Discord::sendFileAsync(const sstring& channel, const sstring& filePath) {
+  if (channel.empty())
+    return;
+
+  std::thread(sendFile, channel, filePath).detach();
+}
+
+namespace {
+  constexpr std::string_view crashLogsDir = "./mutable/crash_logs";
+  constexpr std::string_view lastLogPostedPath =
+    "./mutable/crash_logs/last_asan_log_posted";
+
+  std::string readFileContents(const std::filesystem::path& path) {
+    std::ifstream logFile;
+
+    try {
+      logFile.open(path);
+    } catch (...) {
+      return {};
     }
 
-    vlogf(LOG_MISC, format("Discord webhooks: '%s'")  % msg);
+    std::string logContents((std::istreambuf_iterator<char>(logFile)), {});
+    return logContents;
+  }
 
-    // we want to do this asynchronously so POST lag doesn't hang the mud
-    std::thread thread(sendMessageAsync, channel, msg);
+  std::filesystem::path findNewestCrashLog() {
+    std::filesystem::path newestLogPath;
+    auto latestTime = std::filesystem::file_time_type::min();
 
-    if (!detach) {
-        thread.join();
-    } else {
-        thread.detach();
+    std::filesystem::create_directories(crashLogsDir);
+
+    for (const auto& file : std::filesystem::directory_iterator(crashLogsDir)) {
+      if (file.path().filename().string().find("asan_log.") == 0) {
+        std::string logContents = readFileContents(file);
+
+        // Delete LeakSanitizer logs, as they're created on every graceful
+        // shutdown and we don't want to spam Discord with them. However we
+        // don't want to totally disable them via ASAN_OPTIONS=detect_leaks=0
+        // so we're aware of the leaks.
+        if (logContents.empty() ||
+            logContents.find("LeakSanitizer") != std::string::npos) {
+          std::filesystem::remove(file.path());
+          continue;
+        }
+
+        auto time = std::filesystem::last_write_time(file);
+        if (time > latestTime) {
+          latestTime = time;
+          newestLogPath = file;
+        }
+      }
     }
+
+    return newestLogPath;
+  }
+
+  std::string getLastLogPostedName() {
+    std::ifstream lastLogPosted(lastLogPostedPath.data());
+    std::string logName;
+    std::getline(lastLogPosted, logName);
+    return logName;
+  }
+
+  void writeLastCrashLogPosted(const std::filesystem::path& newestLogPath) {
+    std::ofstream lastLogPosted(lastLogPostedPath.data());
+    lastLogPosted.seekp(0);
+    lastLogPosted.clear();
+    lastLogPosted << newestLogPath.filename().string();
+  }
+}  // namespace
+
+void Discord::maybePostNewestCrashLog() {
+  if (CHANNEL_CRASH_LOGS.empty())
+    return;
+
+  const std::filesystem::path newestLogPath = findNewestCrashLog();
+  const std::string lastLogPostedName = getLastLogPostedName();
+
+  if (newestLogPath.empty() ||
+      newestLogPath.filename().string() == lastLogPostedName) {
+    return;
+  }
+
+  // Discord won't embed a file and display its contents unless it has a
+  // supported extension.
+  std::filesystem::path renamedLogPath = newestLogPath.string() + ".txt";
+  std::filesystem::rename(newestLogPath, renamedLogPath);
+
+  vlogf(LOG_MISC, format("New crash log '%s' found - posting to Discord.") %
+                    renamedLogPath.filename().string());
+
+  Discord::sendFileAsync(Discord::CHANNEL_CRASH_LOGS, renamedLogPath.string());
+
+  writeLastCrashLogPosted(renamedLogPath);
 }

--- a/code/code/misc/discord.cc
+++ b/code/code/misc/discord.cc
@@ -58,6 +58,7 @@ bool Discord::doConfig() {
       format("Discord webhooks: ensure config is located in: '%s'") %
         std::filesystem::current_path());
     vlogf(LOG_MISC, "test");
+    vlogf(LOG_MISC, "test2");
     return false;
   }
 

--- a/code/code/misc/discord.cc
+++ b/code/code/misc/discord.cc
@@ -57,6 +57,7 @@ bool Discord::doConfig() {
     vlogf(LOG_MISC,
       format("Discord webhooks: ensure config is located in: '%s'") %
         std::filesystem::current_path());
+    vlogf(LOG_MISC, "test");
     return false;
   }
 

--- a/code/code/misc/discord.h
+++ b/code/code/misc/discord.h
@@ -1,19 +1,20 @@
 #pragma once
 
-#include "sstring.h"
+class sstring;
 
 class Discord {
-    private: 
-        Discord();
-        static bool sendMessageAsync(sstring channel, sstring msg);
+  public:
+    static sstring CHANNEL_DEATHS;
+    static sstring CHANNEL_SYS;
+    static sstring CHANNEL_ACHIEVEMENT;
+    static sstring CHANNEL_CRASH_LOGS;
+    static int ACHIEVEMENT_THRESHOLD;
 
-    public:
-        static sstring CHANNEL_DEATHS;
-        static sstring CHANNEL_SYS;
-        static sstring CHANNEL_ACHIEVEMENT;
-
-        static int ACHIEVEMENT_THRESHOLD;
-
-        static bool doConfig();
-        static void sendMessage(sstring channel, sstring msg, bool detach = true);
+    Discord() = delete;
+    static bool doConfig();
+    static void maybePostNewestCrashLog();
+    static bool sendFile(const sstring& channel, const sstring& filePath);
+    static void sendFileAsync(const sstring& channel, const sstring& filePath);
+    static bool sendMessage(const sstring& channel, const sstring& msg);
+    static void sendMessageAsync(const sstring& channel, const sstring& msg);
 };

--- a/code/code/misc/limits.cc
+++ b/code/code/misc/limits.cc
@@ -32,7 +32,7 @@ static const sstring ClassTitles(const TBeing *ch)
   for (i = MIN_CLASS_IND; i < MAX_CLASSES; i++) {
     if (ch->getLevel(i)) {
       if ((++count) > 1)
-        sprintf(buf + strlen(buf), "/Level %d %s", 
+        sprintf(buf + strlen(buf), "/Level %d %s",
             ch->getLevel(i), classInfo[i].name.cap().c_str());
       else
         sprintf(buf, "Level %d %s",
@@ -662,12 +662,14 @@ void TPerson::advanceLevel(classIndT Class) {
   if (desc && GetMaxLevel() >= 50) {
     if (desc->career.hit_level50 == 0) {
       desc->career.hit_level50 = time(0);
-      
+
       // discord webhook announcement
       if (GetMaxLevel() == 50) {
         sstring discord_msg;
-        discord_msg = format(":tada: **%s** has achieved level 50 as a **%s**!") % getName() % getProfName();
-        Discord::sendMessage(Discord::CHANNEL_ACHIEVEMENT, discord_msg);
+        discord_msg =
+          format(":tada: **%s** has achieved level 50 as a **%s**!") %
+          getName() % getProfName();
+        Discord::sendMessageAsync(Discord::CHANNEL_ACHIEVEMENT, discord_msg);
       }
     }
     if (isSingleClass()) {
@@ -1488,7 +1490,7 @@ int TBeing::checkIdling() {
       desc = NULL;
       return DELETE_THIS;
     }
-#if 0 
+#if 0
   }
 #else
   } else if (desc && desc->original && (desc->original->getTimer() >= 20)) {
@@ -1525,119 +1527,119 @@ int TBeing::checkIdling() {
     }
   }
 #endif
-    return FALSE;
+  return FALSE;
+}
+
+int TBeing::moneyMeBeing(TThing* mon, TThing* sub) {
+  int rc = mon->moneyMeMoney(this, sub);
+  if (IS_SET_DELETE(rc, DELETE_THIS))
+    return DELETE_ITEM;
+  return FALSE;
+}
+
+void TBeing::classSpecificStuff() {
+  if (hasClass(CLASS_WARRIOR))
+    setMult(1.0);
+
+  if (hasClass(CLASS_MONK)) {
+    // from balance note
+    // we desire monks to be getting 5/7 sqrt(lev) hits per round
+    // barehand prof is linear from L1-L30 : n = 10/3 * L
+    // barehand spec is linear roughly L31-L50 n = (L-30) * 5
+    // solve for L as a function of n
+    double value = 0;
+    if (doesKnowSkill(SKILL_BAREHAND_PROF))
+      value += 3.0 * getSkillValue(SKILL_BAREHAND_PROF) / 10.0;
+    if (doesKnowSkill(SKILL_BAREHAND_SPEC))
+      value += getSkillValue(SKILL_BAREHAND_SPEC) / 5.0;
+
+    // value is roughly their actual level, but based on skill instead
+    value = min(max(1.0, value), 50.0);
+
+    // now make it into numHits
+    value = 5.0 * sqrt(value) / 7.0;
+
+    if (doesKnowSkill(SKILL_ADVANCED_KICKING))
+      value += getSkillValue(SKILL_ADVANCED_KICKING) / 100.0;
+
+    // adjust for speed
+    value *= getStatMod(STAT_SPE);
+
+    // give at least 1 hit per hand
+    // reverse engineering, we realize 2.0 comes around L7.8 = 26%barehand
+    // so this is also a newbie normalization
+    value = max(value, 2.0);
+
+    setMult(value);
+  }
+}
+
+// computes the time it takes to get back 1 point of hp,mana and move
+// it uses worst of the three
+int TBeing::regenTime() {
+  int iTime = 100;
+
+  if (getHit() < hitLimit())
+    iTime = min(iTime, hitGain());
+
+  if (getMove() < moveLimit())
+    iTime = min(iTime, moveGain());
+
+  if (getMana() < manaLimit())
+    iTime = min(iTime, manaGain());
+
+  iTime = max(iTime, 1);
+
+  // iTime now holds the lesser of my mana/move/hp gain (per update)
+  // regen time for 1 point should simply be the inverse multiplied
+  // by how long a points-update is
+  iTime = Pulse::UPDATE / iTime;
+  return iTime;
+}
+
+int TBeing::hpGainForClass(classIndT Class) const {
+  int hpgain = 0;
+
+  // add for classes first
+  if (hasClass(CLASS_MAGE) && Class == MAGE_LEVEL_IND)
+    hpgain += ::number(3, 7);  // old 2,8
+
+  if (hasClass(CLASS_CLERIC) && Class == CLERIC_LEVEL_IND)
+    hpgain += ::number(5, 7);  // old 4,8
+
+  if (hasClass(CLASS_WARRIOR) && Class == WARRIOR_LEVEL_IND)
+    hpgain += ::number(6, 11);  // old 5,12
+
+  if (hasClass(CLASS_THIEF) && Class == THIEF_LEVEL_IND)
+    hpgain += ::number(4, 8);  // old 3,9
+
+  if (hasClass(CLASS_DEIKHAN) && Class == DEIKHAN_LEVEL_IND)
+    hpgain += ::number(6, 9);  // old 5,10
+
+  if (hasClass(CLASS_MONK) && Class == MONK_LEVEL_IND)
+    hpgain += ::number(4, 7);  // old 3,8
+
+  if (hasClass(CLASS_RANGER) && Class == RANGER_LEVEL_IND)
+    hpgain += ::number(6, 8);  // old 5,9
+
+  if (hasClass(CLASS_SHAMAN) && Class == SHAMAN_LEVEL_IND)
+    hpgain += ::number(3, 8);
+
+  return hpgain;
+}
+
+int TBeing::hpGainForLevel(classIndT Class) const {
+  double hpgain = 0;
+
+  hpgain = (double)hpGainForClass(Class);
+
+  hpgain *= (double)getConHpModifier();
+
+  // hpgain /= (double) howManyClasses();
+
+  if (roll_chance(hpgain - (int)hpgain)) {
+    hpgain += 1.0;
   }
 
-  int TBeing::moneyMeBeing(TThing * mon, TThing * sub) {
-    int rc = mon->moneyMeMoney(this, sub);
-    if (IS_SET_DELETE(rc, DELETE_THIS))
-      return DELETE_ITEM;
-    return FALSE;
-  }
-
-  void TBeing::classSpecificStuff() {
-    if (hasClass(CLASS_WARRIOR))
-      setMult(1.0);
-
-    if (hasClass(CLASS_MONK)) {
-      // from balance note
-      // we desire monks to be getting 5/7 sqrt(lev) hits per round
-      // barehand prof is linear from L1-L30 : n = 10/3 * L
-      // barehand spec is linear roughly L31-L50 n = (L-30) * 5
-      // solve for L as a function of n
-      double value = 0;
-      if (doesKnowSkill(SKILL_BAREHAND_PROF))
-        value += 3.0 * getSkillValue(SKILL_BAREHAND_PROF) / 10.0;
-      if (doesKnowSkill(SKILL_BAREHAND_SPEC))
-        value += getSkillValue(SKILL_BAREHAND_SPEC) / 5.0;
-
-      // value is roughly their actual level, but based on skill instead
-      value = min(max(1.0, value), 50.0);
-
-      // now make it into numHits
-      value = 5.0 * sqrt(value) / 7.0;
-
-      if (doesKnowSkill(SKILL_ADVANCED_KICKING))
-        value += getSkillValue(SKILL_ADVANCED_KICKING) / 100.0;
-
-      // adjust for speed
-      value *= getStatMod(STAT_SPE);
-
-      // give at least 1 hit per hand
-      // reverse engineering, we realize 2.0 comes around L7.8 = 26%barehand
-      // so this is also a newbie normalization
-      value = max(value, 2.0);
-
-      setMult(value);
-    }
-  }
-
-  // computes the time it takes to get back 1 point of hp,mana and move
-  // it uses worst of the three
-  int TBeing::regenTime() {
-    int iTime = 100;
-
-    if (getHit() < hitLimit())
-      iTime = min(iTime, hitGain());
-
-    if (getMove() < moveLimit())
-      iTime = min(iTime, moveGain());
-
-    if (getMana() < manaLimit())
-      iTime = min(iTime, manaGain());
-
-    iTime = max(iTime, 1);
-
-    // iTime now holds the lesser of my mana/move/hp gain (per update)
-    // regen time for 1 point should simply be the inverse multiplied
-    // by how long a points-update is
-    iTime = Pulse::UPDATE / iTime;
-    return iTime;
-  }
-
-  int TBeing::hpGainForClass(classIndT Class) const {
-    int hpgain = 0;
-
-    // add for classes first
-    if (hasClass(CLASS_MAGE) && Class == MAGE_LEVEL_IND)
-      hpgain += ::number(3, 7);  // old 2,8
-
-    if (hasClass(CLASS_CLERIC) && Class == CLERIC_LEVEL_IND)
-      hpgain += ::number(5, 7);  // old 4,8
-
-    if (hasClass(CLASS_WARRIOR) && Class == WARRIOR_LEVEL_IND)
-      hpgain += ::number(6, 11);  // old 5,12
-
-    if (hasClass(CLASS_THIEF) && Class == THIEF_LEVEL_IND)
-      hpgain += ::number(4, 8);  // old 3,9
-
-    if (hasClass(CLASS_DEIKHAN) && Class == DEIKHAN_LEVEL_IND)
-      hpgain += ::number(6, 9);  // old 5,10
-
-    if (hasClass(CLASS_MONK) && Class == MONK_LEVEL_IND)
-      hpgain += ::number(4, 7);  // old 3,8
-
-    if (hasClass(CLASS_RANGER) && Class == RANGER_LEVEL_IND)
-      hpgain += ::number(6, 8);  // old 5,9
-
-    if (hasClass(CLASS_SHAMAN) && Class == SHAMAN_LEVEL_IND)
-      hpgain += ::number(3, 8);
-
-    return hpgain;
-  }
-
-  int TBeing::hpGainForLevel(classIndT Class) const {
-    double hpgain = 0;
-
-    hpgain = (double)hpGainForClass(Class);
-
-    hpgain *= (double)getConHpModifier();
-
-    // hpgain /= (double) howManyClasses();
-
-    if (roll_chance(hpgain - (int)hpgain)) {
-      hpgain += 1.0;
-    }
-
-    return max(1, (int)hpgain);
-  }
+  return max(1, (int)hpgain);
+}

--- a/code/code/sys/comm.cc
+++ b/code/code/sys/comm.cc
@@ -78,15 +78,19 @@ int run_the_game() {
   bootDb();
 
   vlogf(LOG_MISC, "Entering game loop.");
-  Discord::sendMessage(Discord::CHANNEL_SYS,":arrow_up: Boot process completed, game is up!");
+  Discord::sendMessageAsync(Discord::CHANNEL_SYS,
+    ":arrow_up: Boot process completed, game is up!");
 
   systask = new SystemTask();
   int ret = gSocket->gameLoop();
   gSocket->closeAllSockets();
 
   vlogf(LOG_MISC, "Normal termination of game.");
-  // detatch = false for this discord message so the program doesn't exit before this thread finished gracefully
-  Discord::sendMessage(Discord::CHANNEL_SYS,":arrow_down: Game has shut down normally.", false);
+  // Send this Discord message synchronously as we want to ensure the message
+  // successfully sends before we exit
+  Discord::sendMessage(Discord::CHANNEL_SYS,
+    ":arrow_down: Game has shut down normally.");
+
   delete gSocket;
 
   return ret;


### PR DESCRIPTION
- Cleans up the existing Discord integration code a bit by following suggestions from clang-tidy/sonarlint/GitHub Copilot
- Implements functionality to automatically post ASan crash logs to a Discord webhook
    - This requires setting an environment variable as follows **before starting the executable**:
        `ASAN_OPTIONS="log_path=<path_to_lib_folder>/mutable/crash_logs/asan_log"`